### PR TITLE
use standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "bankai": "^5.1.3"
+    "bankai": "^5.1.3",
+    "standard": "^8.6.0"
   },
   "dependencies": {
     "choo": "^4.0.1",
@@ -12,6 +13,7 @@
   },
   "scripts": {
     "start": "bankai",
-    "build": "bankai build"
+    "build": "bankai build",
+    "test": "standard"
   }
 }


### PR DESCRIPTION
Adds `standard` to the mix which provides a base layer of validations - currently fails because `data.js` isn't formatted correctly - maybs you could work some regex magic to make it pass? `standard --fix` wasn't able to fix it :(